### PR TITLE
Add deps badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Exfile
 
 [![Build Status](https://travis-ci.org/keichan34/exfile.svg?branch=master)](https://travis-ci.org/keichan34/exfile) [![hex.pm](https://img.shields.io/hexpm/v/exfile.svg)](https://hex.pm/packages/exfile) [![hexdocs](https://img.shields.io/badge/hex-docs-brightgreen.svg)](http://hexdocs.pm/exfile/readme.html)
+[![Deps Status](https://beta.hexfaktor.org/badge/all/github/keichan34/exfile.svg)](https://beta.hexfaktor.org/github/keichan34/exfile)
 
 File upload persistence and processing for Phoenix / Plug, with a focus on
 flexibility and extendability.


### PR DESCRIPTION
Hi there,

I wanted to take the opportunity to pitch my latest project for the Elixir community to you:

  [![Deps Status](https://beta.hexfaktor.org/badge/all/github/keichan34/exfile.svg)](https://beta.hexfaktor.org/github/keichan34/exfile)

This badge shows you an analysis for your dependencies. Behind the badge works a CI service written in Elixir which can notify you whenever important updates for your Hex packages are released. 

This is still in its infancy, and I want to basically invite you to join the beta to test-drive this. I really believe that we can create a great service for the community with this. That said, don't feel any obligation to accept the PR. Just tell me what you think about this idea!

_edit:_ fixed mistakes.
