### PR TITLE
Cast content type ability

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,28 @@ end
 You can specify either an atom (could be `:image`, `:audio`, `:video`) or a list of strings
 `~w(image/bmp image/gif image/jpeg)`.
 
+### Storing metadata to the database
+
+You can `cast_content_type` and store it to the database as a separate field. You need to
+have a string field in your database and go:
+
+``` elixir
+defmodule MyApp.User do
+  # definitions here
+
+  import Exfile.Ecto.CastContentType
+
+  def changeset(model, params) do
+    model
+    |> cast(params, [:avatar])
+    |> cast_content_type(:avatar)
+  end
+end
+```
+
+By default, exfile will save content type to the `avatar_content_type` field. You
+can specify custom field as the third parameter of `cast_content_type` function.
+
 ## Configuration
 
 In `config.exs`:

--- a/lib/exfile/ecto/cast_content_type.ex
+++ b/lib/exfile/ecto/cast_content_type.ex
@@ -1,0 +1,31 @@
+if Code.ensure_loaded?(Ecto) do
+
+defmodule Exfile.Ecto.CastContentType do
+  alias Ecto.Changeset
+  alias Exfile.Processor.ContentType, as: ContentTypeProcessor
+
+  def cast_content_type(changeset, field) when is_atom(field) do
+    cast_content_type(changeset, field, String.to_atom("#{field}_content_type"))
+  end
+  def cast_content_type(changeset, field, content_type_field) when is_atom(content_type_field) do
+    case Changeset.get_change(changeset, field) do
+      %Exfile.File{} -> perform_cast(changeset, field, content_type_field)
+      _              -> changeset
+    end
+  end
+
+  defp perform_cast(changeset, field, content_type_field) do
+    changeset
+    |> Changeset.get_change(field)
+    |> ContentTypeProcessor.call([], [])
+    |> case do
+      { :ok, processed_file } ->
+        changeset
+        |> Changeset.put_change(field, processed_file)
+        |> Changeset.put_change(content_type_field, processed_file.meta["content_type"])
+      _ -> changeset
+    end
+  end
+end
+
+end

--- a/lib/exfile/processor_chain.ex
+++ b/lib/exfile/processor_chain.ex
@@ -44,8 +44,10 @@ defmodule Exfile.ProcessorChain do
   def coerce_to_local_file(%LocalFile{} = local_file),
     do: local_file
   def coerce_to_local_file(%Exfile.File{} = file) do
-    {:ok, local_file} = Exfile.File.open(file)
-    local_file
+    case Exfile.File.open(file) do
+      { :ok, local_file } -> local_file
+      { :error, _ }       -> %LocalFile{}
+    end
   end
 
   defp do_process(_, {:error, _} = error_term),

--- a/test/exfile/ecto/cast_content_type_test.exs
+++ b/test/exfile/ecto/cast_content_type_test.exs
@@ -1,0 +1,47 @@
+defmodule Exfile.Ecto.CastContentTypeTest do
+  use ExUnit.Case, async: true
+
+  import Ecto.Changeset, only: [cast: 3]
+  import Exfile.Ecto.CastContentType
+
+  test "assigns content type correctly" do
+    changeset = cast(initial_changeset, %{ image: image_file }, [:image])
+      |> cast_content_type(:image)
+
+    assert changeset.changes[:image_content_type] == "image/jpeg"
+  end
+
+  test "doesn't assign anything if file is not present in changeset" do
+    changeset = cast(initial_changeset, %{ image: nil }, [:image])
+      |> cast_content_type(:image)
+
+    assert changeset.changes[:image_content_type] == nil
+  end
+
+  test "ability to use custom field name" do
+    changeset = cast(initial_changeset, %{ image: image_file }, [:image])
+      |> cast_content_type(:image, :image_custom_type)
+
+    assert changeset.changes[:image_custom_type] == "image/jpeg"
+  end
+
+  defp initial_changeset do
+    data  = %{
+      image: nil,
+      image_content_type: nil,
+      image_custom_type: nil
+    }
+
+    types = %{
+      image: Exfile.Ecto.File,
+      image_content_type: :string,
+      image_custom_type: :string
+    }
+
+    { data, types }
+  end
+
+  defp image_file do
+    %Plug.Upload{ path: "test/fixtures/sample.jpg", filename: "sample.jpg" }
+  end
+end


### PR DESCRIPTION
I'm introducing `cast_content_type` ability here. Idea is pretty simple: it allows to store content type of uploaded file in the database. It based on content type processor, so let's merge PR #28 first.
- [x] Wait for #28 to be merged and rebase
- [x] Write functionality
- [x] Write tests
- [x] Update README.md

/cc @keichan34 
