### PR TITLE
Crypto deprecation

### DIFF
--- a/lib/exfile/hasher/random.ex
+++ b/lib/exfile/hasher/random.ex
@@ -2,6 +2,6 @@ defmodule Exfile.Hasher.Random do
   @behaviour Exfile.Hasher
 
   def hash(_uploadable) do
-    :crypto.rand_bytes(30) |> Base.encode16(case: :lower)
+    :crypto.strong_rand_bytes(30) |> Base.encode16(case: :lower)
   end
 end


### PR DESCRIPTION
I'm getting ugly and annoying deprecation

``` elixir
warning: crypto:rand_bytes/1 is deprecated and will be removed in a future release; use crypto:strong_rand_bytes/1
```

on every compilation. Let's remove it
