### PR TITLE
Do not add processed file back to changeset in cast_content_type. 

### DIFF
--- a/lib/exfile/ecto/cast_content_type.ex
+++ b/lib/exfile/ecto/cast_content_type.ex
@@ -21,7 +21,6 @@ defmodule Exfile.Ecto.CastContentType do
     |> case do
       { :ok, processed_file } ->
         changeset
-        |> Changeset.put_change(field, processed_file)
         |> Changeset.put_change(content_type_field, processed_file.meta["content_type"])
       _ -> changeset
     end


### PR DESCRIPTION
Fixes  #43 and #48 which currently occur if you add `cast_content_type` before adding `cast_filename`.