### PR TITLE
Gracefully handle non-existant exfile field

### DIFF
--- a/lib/exfile/ecto.ex
+++ b/lib/exfile/ecto.ex
@@ -24,26 +24,33 @@ defmodule Exfile.Ecto do
   """
   def prepare_uploads(changeset, fields) do
     Changeset.prepare_changes(changeset, fn changeset ->
-      perform_uploads!(changeset, fields)
+      perform_uploads(changeset, fields)
     end)
   end
 
-  defp perform_uploads!(changeset, fields) do
-    Enum.reduce fields, changeset, fn
-      (field, changeset) ->
-        t = ecto_type_for_field(changeset.data, field)
-        file = Changeset.get_field(changeset, field)
-        case t.upload!(file) do
-          {:ok, uploaded_file} ->
-            Changeset.put_change(changeset, field, uploaded_file)
-          error ->
-            throw error
-        end
+  defp perform_uploads(changeset, fields) do
+    Enum.reduce fields, changeset, fn (field, changeset) ->
+      perform_upload(changeset, field)
     end
   end
 
+  defp perform_upload(changeset, field) do
+    with {:ok, t} <- ecto_type_for_field(changeset.data, field),
+      file when not is_nil(file) <- Changeset.get_field(changeset, field),
+      {:ok, uploaded_file} <- t.upload!(file)
+    do
+      Changeset.put_change(changeset, field, uploaded_file)
+    else
+      nil -> #happens if an exfile field is optional and thus might not be set 
+        changeset
+      _ ->
+        throw "Upload failed"
+    end
+
+  end
+
   defp ecto_type_for_field(%{__struct__: mod}, field) do
-    mod.__schema__(:type, field)
+    {:ok, mod.__schema__(:type, field)}
   end
 end
 

--- a/lib/exfile/ecto.ex
+++ b/lib/exfile/ecto.ex
@@ -24,24 +24,24 @@ defmodule Exfile.Ecto do
   """
   def prepare_uploads(changeset, fields) do
     Changeset.prepare_changes(changeset, fn changeset ->
-      perform_uploads(changeset, fields)
+      perform_uploads!(changeset, fields)
     end)
   end
 
-  defp perform_uploads(changeset, fields) do
+  defp perform_uploads!(changeset, fields) do
     Enum.reduce fields, changeset, fn (field, changeset) ->
-      perform_upload(changeset, field)
+      perform_upload!(changeset, field)
     end
   end
 
-  defp perform_upload(changeset, field) do
+  defp perform_upload!(changeset, field) do
     with {:ok, t} <- ecto_type_for_field(changeset.data, field),
       file when not is_nil(file) <- Changeset.get_field(changeset, field),
       {:ok, uploaded_file} <- t.upload!(file)
     do
       Changeset.put_change(changeset, field, uploaded_file)
     else
-      nil -> #happens if an exfile field is optional and thus might not be set 
+      nil -> #happens if an exfile field is optional and thus might not be set
         changeset
       _ ->
         throw "Upload failed"

--- a/lib/exfile/ecto.ex
+++ b/lib/exfile/ecto.ex
@@ -43,8 +43,8 @@ defmodule Exfile.Ecto do
     else
       nil -> #happens if an exfile field is optional and thus might not be set
         changeset
-      _ ->
-        throw "Upload failed"
+      error ->
+        throw error
     end
 
   end

--- a/test/exfile/ecto_test.exs
+++ b/test/exfile/ecto_test.exs
@@ -9,20 +9,32 @@ defmodule Exfile.EctoTest do
 
     image_file = %Plug.Upload{ path: "test/fixtures/sample.jpg", filename: "sample.jpg" }
     changeset = cast(%Exfile.S.Image{}, %{image: image_file}, [:image])
+    changeset_without_image = cast(%Exfile.S.Image{}, %{}, [])
 
-    {:ok, %{ changeset: changeset }}
+    {:ok, %{ changeset: changeset, changeset_without_image: changeset_without_image }}
   end
 
   test "prepare_uploads/2 saves a file from the cache backend to the store backend", %{changeset: changeset} do
 
     assert get_field(changeset, :image).backend.backend_name == "cache"
-
     assert {:ok, data} = changeset
     |> prepare_uploads([:image])
     |> Exfile.Repo.insert
 
     assert data.image.backend.backend_name == "store"
   end
+
+  test "prepare_uploads/2 ignores a file field with null value", %{changeset_without_image: changeset} do
+
+    assert get_field(changeset, :image) == nil
+
+    assert {:ok, data} = changeset
+    |> prepare_uploads([:image])
+    |> Exfile.Repo.insert
+
+    assert data.image == nil
+  end
+
 
   test "prepare_uploads/2 doesn't save the file to store if there are errors", %{changeset: changeset} do
     changeset = add_error(changeset, :image_content_type, "invalid")
@@ -34,4 +46,5 @@ defmodule Exfile.EctoTest do
     assert get_field(error_changeset, :image).id == get_field(changeset, :image).id
     assert get_field(error_changeset, :image).backend.backend_name == "cache"
   end
+
 end


### PR DESCRIPTION
Use Case:  In my ecto model `:profile_picture` is an _optional_ `Exfile.Ecto.File` field. 

When I call the below changeset function with profile_picture not being set exfile raises an `no function clause matching in Exfile.Backend.FileSystem.upload/2` error when calling `Exfile.Ecto.prepare_uploads([:profile_picture])`. This pull request fixes the problem.

```
def changeset(%Person{} = person attrs) do
    person
    |> cast(attrs, [:lastname, :firstname, :profile_picture, :birthday, :parents, :street, :postal_code, :town, :phone1_label, :phone1, :phone2_label, :phone2, :phone3_label, :phone3, :mail1, :mail2, :group_id])
    |> validate_required([:lastname, :firstname])
    |> validate_content_type(:profile_picture, :image)
    |> Exfile.Ecto.prepare_uploads([:profile_picture])
  end
```
