### PR TITLE
Add connection pid monitoring

### DIFF
--- a/lib/exfile/backend/file_system.ex
+++ b/lib/exfile/backend/file_system.ex
@@ -43,7 +43,9 @@ defmodule Exfile.Backend.FileSystem do
     end
   end
 
-  def upload(backend, %Exfile.File{} = other_file) do
+  def upload(backend, file, monitor_pid \\ nil)
+
+  def upload(backend, %Exfile.File{} = other_file, _monitor_pid) do
     case Exfile.File.open(other_file) do
       {:ok, local_file} ->
         upload(backend, local_file)
@@ -52,9 +54,9 @@ defmodule Exfile.Backend.FileSystem do
     end
   end
 
-  def upload(backend, %LocalFile{} = local_file) do
+  def upload(backend, %LocalFile{} = local_file, monitor_pid) do
     id = backend.hasher.hash(local_file)
-    %LocalFile{path: path} = LocalFile.copy_to_tempfile(local_file)
+    %LocalFile{path: path} = LocalFile.copy_to_tempfile(local_file, monitor_pid)
     File.copy!(path, path(backend, id))
     {:ok, get(backend, id)}
   end

--- a/lib/exfile/router.ex
+++ b/lib/exfile/router.ex
@@ -170,7 +170,7 @@ defmodule Exfile.Router do
   end
   defp stream_file(%{assigns: %{exfile_local_file: %LocalFile{io: io}}} = conn) when not is_nil(io) do
     data = IO.binread(io, :all)
-    file = Exfile.Tempfile.random_file!("send")
+    file = Exfile.Tempfile.random_file!("send", connection_pid(conn))
     File.write!(file, data, [:write])
 
     conn
@@ -197,7 +197,7 @@ defmodule Exfile.Router do
     backend = Config.get_backend(backend)
     conn = put_resp_content_type(conn, "application/json")
 
-    case Exfile.Backend.upload(backend, local_file) do
+    case Exfile.Backend.upload(backend, local_file, connection_pid(conn)) do
       {:ok, file} ->
         uri = Exfile.File.uri(file)
         send_resp(conn, 200, ~s({"id":"#{file.id}","uri":"#{uri}"}))
@@ -215,5 +215,15 @@ defmodule Exfile.Router do
     |> :calendar.gregorian_seconds_to_datetime
     |> :httpd_util.rfc1123_date
     |> to_string
+  end
+
+  defp connection_pid(%Plug.Conn{adapter: adapter}) do
+    case adapter do
+      {Plug.Cowboy.Conn, %{pid: connection_pid}} ->
+        connection_pid
+
+      _ ->
+        self()
+    end
   end
 end


### PR DESCRIPTION
Start #64.

It should solve the connection monitoring issue with temp files.

I read the cowboy source code and noticed that it always sends the response from the connection process, not the request one. 

It means that we have to pass the connection pid from the `Plug.Conn` down to the `Exfile.Tempfile`, creating some ugly code as a result. But at least it relies on the least amount of hacks and avoids having separate cleaning worker.

@keichan34 what do you think?